### PR TITLE
feat: 添加homebrew支持，确保可以通过console触发brew安装技能依赖

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -62,6 +62,14 @@ USER node
 ENV HOME=/home/node
 WORKDIR /home/node
 
+# 安装linuxbrew（Homebrew 的 Linux 版本），并配置环境变量
+RUN mkdir -p /home/node/.linuxbrew/Homebrew && \
+    git clone --depth 1 https://github.com/Homebrew/brew /home/node/.linuxbrew/Homebrew && \
+    mkdir -p /home/node/.linuxbrew/bin && \
+    ln -s /home/node/.linuxbrew/Homebrew/bin/brew /home/node/.linuxbrew/bin/brew && \
+    chown -R node:node /home/node/.linuxbrew && \
+    chmod -R g+rwX /home/node/.linuxbrew
+
 RUN cd /home/node/.openclaw/extensions && \
   git clone --depth 1 https://github.com/soimy/openclaw-channel-dingtalk.git dingtalk && \
   cd dingtalk && \
@@ -101,7 +109,11 @@ ENV HOME=/home/node \
     NODE_PATH=/usr/local/lib/node_modules \
     LANG=en_US.UTF-8 \
     LANGUAGE=en_US:en \
-    LC_ALL=en_US.UTF-8
+    LC_ALL=en_US.UTF-8 \
+    NODE_ENV=production \
+    PATH="/home/node/.linuxbrew/bin:/home/node/.linuxbrew/sbin:/usr/local/lib/node_modules/.bin:${PATH}" \
+    HOMEBREW_NO_AUTO_UPDATE=1 \
+    HOMEBREW_NO_INSTALL_CLEANUP=1
 
 # 暴露端口
 EXPOSE 18789 18790


### PR DESCRIPTION
此PR更新了 `Dockerfile`，增加了对 Linuxbrew（Homebrew 的 Linux 版本）的支持，并配置了相关环境变量，以增强容器内的包管理能力。此次修改还设置了多个环境变量，用于优化 Homebrew 的行为，并确保应用程序的正确执行环境。

**Linuxbrew 安装与配置：**

- 通过将 Homebrew 仓库克隆至 `/home/node/.linuxbrew` 来安装 Linuxbrew，创建必要的符号链接，并为 `node` 用户设置适当的权限。

**环境变量增强：**

- 添加了 `NODE_ENV=production` 并更新了 `PATH` 以包含 Linuxbrew 的二进制文件，确保已安装的软件包可以被访问。同时设置了 `HOMEBREW_NO_AUTO_UPDATE=1` 和 `HOMEBREW_NO_INSTALL_CLEANUP=1`，以防止 Homebrew 自动更新和清理，从而提高构建的一致性。