### PR TITLE
fix: 修复动态端口配置导致的服务访问问题

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -182,7 +182,7 @@ OPENCLAW_GATEWAY_PORT=18789
 OPENCLAW_BRIDGE_PORT=18790
 OPENCLAW_GATEWAY_MODE=local
 # 允许的 Origin 域，多个用逗号隔开
-OPENCLAW_GATEWAY_ALLOWED_ORIGINS=http://localhost
+OPENCLAW_GATEWAY_ALLOWED_ORIGINS=http://localhost:$OPENCLAW_GATEWAY_PORT
 # 允许不安全认证（如 http），可选 true/false
 OPENCLAW_GATEWAY_ALLOW_INSECURE_AUTH=true
 # 危险：禁用设备认证（如在 Docker 环境中无法获取设备信息），可选 true/false

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -187,8 +187,8 @@ services:
       # 使用命名卷共享 extensions，确保工具容器安装后的插件主容器可见
       - openclaw-extensions:/home/node/.openclaw/extensions
     ports:
-      - "${OPENCLAW_GATEWAY_PORT}:18789"
-      - "${OPENCLAW_BRIDGE_PORT}:18790"
+      - "${OPENCLAW_GATEWAY_PORT}:${OPENCLAW_GATEWAY_PORT}"
+      - "${OPENCLAW_BRIDGE_PORT}:${OPENCLAW_BRIDGE_PORT}"
     init: true
     restart: unless-stopped
 


### PR DESCRIPTION
1. docker-compose.yml 端口映射改为动态映射，内部服务使用环境变量配置的端口，避免外部无法访问
2. .env.example 允许的 Origin 域绑定 Gateway 端口，解决跨域访问被拒绝的问题